### PR TITLE
Use canonical Status and content address conditions

### DIFF
--- a/architecture/models.py
+++ b/architecture/models.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, asdict
-from enum import Enum, auto
+from enum import Enum
 from typing import Any, Dict, List, Optional
 import uuid
 
-
-class Status(Enum):
-    UNKNOWN = auto()
-    SATISFIED = auto()
-    VIOLATED = auto()
+from workflow import Status  # re-export as the canonical Status
 
 
 class PlanKind(Enum):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -13,6 +13,7 @@ from workflow import (
     Scheduler,
     Status,
     ValidationResult,
+    compute_digest,
 )
 
 
@@ -68,4 +69,11 @@ def test_scheduler_respects_task_budget():
     asyncio.run(sched.run(handler))
     assert g.node(n1.key).status is Status.SATISFIED
     assert g.node(n2.key).status is Status.UNKNOWN
+
+
+def test_condition_digest_includes_plan_and_params():
+    d1 = compute_digest("A", "X", {"p": 1})
+    d2 = compute_digest("A", "X", {"p": 2})
+    d3 = compute_digest("A", "Y", {"p": 1})
+    assert len({d1, d2, d3}) == 3
 


### PR DESCRIPTION
## Summary
- re-export scheduler's Status enum so CANCELLED is recognized everywhere
- dedupe conditions by content digest including plan info
- assert Status type and test digest uniqueness

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d0b0b7fc8324856aecadceb24786