### PR TITLE
Fix orchestrator script imports

### DIFF
--- a/architecture/orchestrator.py
+++ b/architecture/orchestrator.py
@@ -7,6 +7,13 @@ import asyncio
 from asyncio import CancelledError
 import time
 import uuid
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the import path when running this module as a script.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+if __package__ in (None, ""):
+    __package__ = "architecture"
 
 from persistence import RunStore, BlobStore, RunEvent, EventType, DerivedState
 


### PR DESCRIPTION
## Summary
- ensure `architecture/orchestrator` can import project modules when run directly

## Testing
- `pytest -q`
- `python architecture/orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_6897d4d91a588324942cf637fb00ec4b